### PR TITLE
add modparam to support rabbitmq heartbeat

### DIFF
--- a/modules/event_rabbitmq/event_rabbitmq.h
+++ b/modules/event_rabbitmq/event_rabbitmq.h
@@ -62,13 +62,13 @@
 
 typedef struct _rmq_params {
 	str exchange;
-	str routing_key;
 	str user;
 	str pass;
 	amqp_connection_state_t conn;
 	int sock;
 	int channel;
 	int flags;
+	int heartbeat;
 } rmq_params_t;
 
 #endif


### PR DESCRIPTION
This implementation enables the rabbitmq's client side's heartbeat negotiation.

Problem:
Because of TCP's nature, it takes very long time for a TCP peer to make the decision of closing the local socket. Before this implementation, Opensips 1.9 doesn't handle the situation well and it stop processing UDP packets until the O.S decides to close the local socket. One of the consequence is that UAC cannot register to the registrar during this time period.

Solution:
If the module, even_rabbitmq/rabbitmq-client, doesn't get a heartbeat message from the rabbitmq-server within X seconds, the rabbitmq-client will kill the local socket connection actively.

Add:
modparam("event_rabbitmq", "heartbeat", [X seconds])
