### PR TITLE
Hotfix/CPATL-1254

### DIFF
--- a/net/proto_tcp/proto_tcp.c
+++ b/net/proto_tcp/proto_tcp.c
@@ -603,7 +603,7 @@ poll_loop:
 		}
 	}
 
-	if (pf.events&POLLOUT)
+	if (pf.revents&POLLOUT)
 		goto again;
 
 	/* some other events triggered by poll - treat as errors */


### PR DESCRIPTION
TCP pollout event check fix. Package opensips-2.1-88.x86_64.rpm built from this branch. After Emily confirms the changes work as expected under load, we'll merge branch with base.
